### PR TITLE
During the test to download files from nginx_ofp, the timer added by …

### DIFF
--- a/src/event/modules/ngx_select_module.c
+++ b/src/event/modules/ngx_select_module.c
@@ -347,6 +347,10 @@ ngx_select_process_events(ngx_cycle_t *cycle, ngx_msec_t timer,
 	}
 
 #if OFP_NOTIFY
+    if (flags & NGX_UPDATE_TIME || ngx_event_timer_alarm) {
+        ngx_time_update();
+    }
+    
     return NGX_OK;
 #endif
     int                ready, nready;

--- a/src/event/ngx_event.c
+++ b/src/event/ngx_event.c
@@ -195,11 +195,12 @@ void
 ngx_process_events_and_timers(ngx_cycle_t *cycle)
 {
     ngx_uint_t  flags;
-    ngx_msec_t  timer, delta;
+    ngx_msec_t  timer;
+    static ngx_msec_t delta = 0;
 
     if (1) {
         timer = NGX_TIMER_INFINITE;
-        flags = 0;
+        flags = NGX_UPDATE_TIME;
 
     } else {
         timer = ngx_event_find_timer();
@@ -238,7 +239,6 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
         }
     }
 
-    delta = ngx_current_msec;
 
     (void) ngx_process_events(cycle, timer, flags);
 
@@ -255,6 +255,7 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
 
     if (delta) {
         ngx_event_expire_timers();
+        delta = ngx_current_msec;
     }
 
     ngx_event_process_posted(cycle, &ngx_posted_events);


### PR DESCRIPTION
…ngx_event_add_timer (e.g, via ngx_http_set_write_handler) can't be invoked. The reason is that ngx_current_msec can't be updated and delta for ngx_event_expire_timers usually equals to 0.