### PR TITLE
Diverse patches for NGiNX

### DIFF
--- a/README
+++ b/README
@@ -109,9 +109,6 @@ To get NGINX debug logs uncomment the debug line
 To run more on more cores increase the number of worker processes:
  worker_processes  number;
 
-One also needs to set the NUM_QUEUES environment variable to the same
-value as worker_processes (see 3. Running NGINX).
-
 Debug logs will be in /usr/local/nginx_dpdk/logs/error.log
 
 3. Running NGINX
@@ -120,10 +117,6 @@ Debug logs will be in /usr/local/nginx_dpdk/logs/error.log
 Be sure you have configured DPDK and interfaces as explained at 0.2.
 
 In conf/ofp.conf file, configure the ip address for fp0 interface.
-
-When using more than one worker, set NUM_QUEUES in start_nginx.sh
-(uncomment the export command) to the same value as worker_processes
-in nginx.conf.
 
 To start webserver:
  sh start_nginx.sh 0

--- a/auto/install
+++ b/auto/install
@@ -37,6 +37,7 @@ esac
 
 
 NGX_CONF_PREFIX=`dirname $NGX_CONF_PATH`
+NGX_SBIN_PREFIX=`dirname $NGX_SBIN_PATH`
 
 
 case ".$NGX_PID_PATH" in
@@ -145,6 +146,14 @@ install:	$NGX_OBJS${ngx_dirsep}nginx${ngx_binext} \
 
 	test -d '\$(DESTDIR)$NGX_PREFIX/html' \
 		|| cp -R $NGX_HTML '\$(DESTDIR)$NGX_PREFIX'
+
+	sed -e "s|%%NGX_SBIN_PATH%%|$NGX_SBIN_PREFIX|" \
+	    -e "s|%%NGX_CONF_PREFIX%%|$NGX_CONF_PREFIX|" start_nginx.sh > \
+		'\$(DESTDIR)$NGX_SBIN_PREFIX/start_nginx.sh'
+	chmod u+x '\$(DESTDIR)$NGX_SBIN_PREFIX/start_nginx.sh'
+	sed -e "s|%%NGX_PID_PATH%%|$NGX_PID_PATH|" stop_nginx.sh > \
+		'\$(DESTDIR)$NGX_SBIN_PREFIX/stop_nginx.sh'
+	chmod u+x '\$(DESTDIR)$NGX_SBIN_PREFIX/stop_nginx.sh'
 END
 
 

--- a/auto/install
+++ b/auto/install
@@ -154,6 +154,7 @@ install:	$NGX_OBJS${ngx_dirsep}nginx${ngx_binext} \
 	sed -e "s|%%NGX_PID_PATH%%|$NGX_PID_PATH|" stop_nginx.sh > \
 		'\$(DESTDIR)$NGX_SBIN_PREFIX/stop_nginx.sh'
 	chmod u+x '\$(DESTDIR)$NGX_SBIN_PREFIX/stop_nginx.sh'
+	cp conf/ofp.conf '\$(DESTDIR)$NGX_CONF_PREFIX'
 END
 
 

--- a/src/event/modules/ngx_select_module.c
+++ b/src/event/modules/ngx_select_module.c
@@ -147,7 +147,6 @@ static void sigev_notify(union ofp_sigval sv)
         ss->pkt = ODP_PACKET_INVALID;
     }
 
-end:
     return;
 }
 #endif

--- a/start_nginx.sh
+++ b/start_nginx.sh
@@ -11,7 +11,7 @@ intf=$1
 echo Starting $app on interface $intf
 
 # Find number of queues from config file
-CONFIG_FILE=/usr/local/nginx_dpdk/nginx.conf
+CONFIG_FILE=%%NGX_CONF_PREFIX%%/nginx.conf
 line=$(grep -m 1 '^\s*worker_processes' $CONFIG_FILE)
 if [ -n "$line" ]; then
     NUM_QUEUES=$(echo $line | sed -r 's/^\s*worker_processes\s+([0-9])\s*;/\1/')
@@ -19,7 +19,7 @@ if [ -n "$line" ]; then
     export NUM_QUEUES
 fi
 
-/usr/local/nginx_dpdk/nginx &
+%%NGX_SBIN_PATH%%/nginx &
 
 #sleep 1
 #ifconfig fp0 $2

--- a/start_nginx.sh
+++ b/start_nginx.sh
@@ -10,7 +10,14 @@ fi
 intf=$1
 echo Starting $app on interface $intf
 
-#export NUM_QUEUES=1
+# Find number of queues from config file
+CONFIG_FILE=/usr/local/nginx_dpdk/nginx.conf
+line=$(grep -m 1 '^\s*worker_processes' $CONFIG_FILE)
+if [ -n "$line" ]; then
+    NUM_QUEUES=$(echo $line | sed -r 's/^\s*worker_processes\s+([0-9])\s*;/\1/')
+    echo "Found $NUM_QUEUES worker_processes"
+    export NUM_QUEUES
+fi
 
 /usr/local/nginx_dpdk/nginx &
 

--- a/stop_nginx.sh
+++ b/stop_nginx.sh
@@ -10,7 +10,7 @@ if test "X$intf" = "X"; then intf=eth0; fi
 app="nginx"
 echo "Stopping $app"
 
-kill -9 `cat /usr/local/nginx_dpdk/nginx.pid`
+kill -9 `cat %%NGX_PID_PATH%%`
 
 ps -e | grep '\s\+nginx$' | awk '{print $1}' | xargs kill -9
 
@@ -22,4 +22,4 @@ ps -e | grep '\s\+nginx$' | awk '{print $1}' | xargs kill -9
 #ifconfig $intf arp
 #
 #ifconfig eth0 192.168.1.4/24 up
-mv /usr/local/nginx_dpdk/nginx.pid /usr/local/nginx_dpdk/nginx.pid.bk
+mv %%NGX_PID_PATH%% %%NGX_PID_PATH%%.bk

--- a/stop_nginx.sh
+++ b/stop_nginx.sh
@@ -12,7 +12,7 @@ echo "Stopping $app"
 
 kill -9 `cat /usr/local/nginx_dpdk/nginx.pid`
 
-ps -eL | grep nginx | awk '{print $1}' | xargs kill -9
+ps -e | grep '\s\+nginx$' | awk '{print $1}' | xargs kill -9
 
 #ifconfig $intf down
 #iptables -D FORWARD -i $intf -j DROP


### PR DESCRIPTION
The main reason for this series is to install start/stop_nginx.sh to the system directories, so they are available upon "make install", and put ofp.conf to NGiNX' configuration directory, honoring the option in ./configure (currently it expects the file to be at ./config/ofp.conf).
Also, now since NGiNX reads the NUM_QUEUES environment variable, the nginx_start.sh script will set it properly in accordance to worker_processes in nginx.conf.